### PR TITLE
Fix parsing precedence for negative numbers

### DIFF
--- a/core/syntax.y
+++ b/core/syntax.y
@@ -261,8 +261,8 @@ true = "true" !utfw
 false = "false" !utfw
 hexl = [0-9A-Fa-f]
 hex = '0x' < hexl+ >
-# wrong x-1 parsing precedence, whitespace #75
-dec = < ('0' | '-'? [1-9][0-9]*) { $$ = YY_TINT; }
+
+dec = < ('0' | [1-9][0-9]*) { $$ = YY_TINT; }
         ('.' [0-9]+ { $$ = YY_TDBL; })?
         ('e' [-+] [0-9]+ { $$ = YY_TDBL })? >
 


### PR DESCRIPTION
wrong x-1 parsing precedence, whitespace #75 

please test before pulling, as I'm not 100% sure this will work in all cases. I think it will, at the expense of a tiny bit of speed because the number is negated after being created, but I think it's probably small enough not to worry about.

Negative numbers are not really used often in inner loops :smiley: 