### PR TITLE
Add rsync to the external build dependency list

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ gcc-4.6.3 is broken, at least on ubuntu.
 
 ## ~ external dependencies ~
 
-    build-time: gnu make, perl, sed, gcc or clang, echo, cat, expr, git
+    build-time: gnu make, perl, sed, gcc or clang, echo, cat, expr, git, rsync
     perl is only needed because of BSD/darwin sed problems
 
     run-time:


### PR DESCRIPTION
Turns out `rsync` is also necessary to build potion, so I added it to the list of external build dependencies.